### PR TITLE
add set_boto_retry_attemps_config_option() function

### DIFF
--- a/aws_utils/utils.py
+++ b/aws_utils/utils.py
@@ -1,0 +1,12 @@
+try:
+    import configparser 
+except ImportError:
+    import ConfigParser as configparser
+import boto
+
+def set_boto_retry_attemps_config_option(num_of_attempts):
+    try:
+        boto.config.add_section("Boto")
+    except configparser.DuplicateSectionError:
+        pass
+    boto.config.set("Boto", "metadata_service_num_attempts", str(num_of_attempts))


### PR DESCRIPTION
we are adding function that in audience-data-store was called setup_boto and renaming it with something more descriptive. We will be reusing this function in audience-insights project
