### PR TITLE
Add save_jsonfile_to_s3

### DIFF
--- a/aws_utils/s3/s3_utils.py
+++ b/aws_utils/s3/s3_utils.py
@@ -341,6 +341,11 @@ def load_jsonfile_from_s3(bucket, path):
     return [json.loads(item) for item in file_contents.splitlines()]
 
 
+def save_jsonfile_to_s3(bucket, path, items, **kwargs):
+    file_contents = "\n".join(json.dumps(item) for item in items)
+    save_to_s3(bucket, path, file_contents, **kwargs)
+
+
 def get_bucket_and_path_from_uri(path):
     """Returns a list containing S3 bucket and path from a URI.
 


### PR DESCRIPTION
Inverse of `load_jsonfile_from_s3`.

IMO `load_jsonfile_from_s3` should be called `get_jsonfile_from_s3` given `get_from_s3` and `save_to_s3`. Should I add an alias?