### PR TITLE
Fix urlparse for Python 3

### DIFF
--- a/aws_utils/s3/s3_utils.py
+++ b/aws_utils/s3/s3_utils.py
@@ -30,7 +30,7 @@ except ImportError:
 try:
     from urlparse import urlparse
 except ImportError:
-    from urllib import parse as urlparse
+    from urllib.parse import urlparse
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
`urllib.parse` is a module, not a function!