### PR TITLE
fix: bump smart open version to solve the boto host issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '0.4.2'
 INSTALL_REQUIRES = [
     'boto>=2.38.0',# need to stay in this version as sqs.get_queue function stops working when we upgrade
     'boto3>=1.2.3',
-    'smart_open==1.3.2',# smart open must be 1.3.2 because in 1.3.3 onward the gzip write functionality has been removed
+    'smart_open==1.3.3',# smart open must be 1.3.3 because later versions break out merge part files function in data-store mappers
     'dateutils>=0.6.6',
     'retrying>=1.3.3'
 ]


### PR DESCRIPTION
1.3.3 is still safe, but it includes the rob fix for our boto host connection issues